### PR TITLE
Refine game theme and add Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - theme-refresh
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,75 @@
+name: Deploy GitHub Pages
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout workflow dispatch ref
+        uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Checkout successful CI commit
+        uses: actions/checkout@v4
+        if: github.event_name == 'workflow_run'
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for GitHub Pages
+        env:
+          PAGES_BASE: ${{ github.event_name == 'workflow_dispatch' && github.event.repository.name || github.event.workflow_run.repository.name }}
+        run: npm run build -- --base="/${PAGES_BASE}/"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,16 @@
+## Design Context
+
+### Users
+Players are dropping into a lightweight browser tower defense game on desktop and mobile. They need a quick-read battlefield, tactile tower selection, and UI that feels like part of the play surface instead of a surrounding website.
+
+### Brand Personality
+Arcade, tactical, and tangible. The interface should feel like an evening tabletop setup with lit controls, a physical board, and readable game-state instrumentation.
+
+### Aesthetic Direction
+Use an arcade board-game direction with a low-light table atmosphere. Keep the existing responsive layout structure, including the sidebar, but restyle panels into control modules instead of generic cards. Avoid website-like neutral surfaces, soft SaaS spacing, and editorial serif page treatment.
+
+### Design Principles
+1. The battlefield is the hero, and all supporting UI should frame it like hardware around a board.
+2. Panels should feel tactile and game-native through material contrast, compact spacing, and strong state styling.
+3. Information density is acceptable when grouped like a HUD, not like content sections on a website.
+4. Desktop and mobile should share the same visual language, even if controls reflow.

--- a/docs/superpowers/specs/2026-04-19-tower-defense-theme-design.md
+++ b/docs/superpowers/specs/2026-04-19-tower-defense-theme-design.md
@@ -1,0 +1,47 @@
+# Tower Defense Theme Refresh Design
+
+## Goal
+Shift the current interface away from a website-like presentation and toward a tower-defense-specific game theme without changing the core responsive layout structure shared across desktop and mobile.
+
+## Confirmed Constraints
+- Keep the main desktop/mobile layout skeleton, including the sidebar.
+- Focus changes on presentation details such as spacing, palette, surfaces, typography, and button styling.
+- Preserve the current gameplay structure and information architecture.
+
+## Design Direction
+Adopt an "arcade tactical board" theme with the mood of a board game played under evening lighting. The board should feel like a physical play surface, while the HUD and sidebar should read as attached control hardware rather than content cards.
+
+## Visual System
+- Replace the current light parchment website palette with a darker table-surface palette built from olive, brass, ember, and charcoal tones.
+- Use stronger material separation between page background, battlefield frame, HUD strip, and side control modules.
+- Replace the current document-like serif-led presentation with a display font for game headings and a compact readable UI font for controls and labels.
+- Reduce roomy website spacing and make panels denser and more instrument-like.
+
+## Layout Treatment
+- Keep the current two-column desktop layout and the mobile dock pattern.
+- Convert the top HUD from a row of standalone cards into a cohesive scoreboard strip.
+- Restyle sidebar sections so they feel like stacked control bays with inset surfaces and stronger selection states.
+- Keep the board visually dominant by increasing contrast and theatrical framing around the canvas area.
+
+## Interaction Styling
+- Tower choice buttons should feel like selectable unit tokens or loadout slots, not website cards.
+- Primary action buttons should look tactile and pressable with stronger active and selected states.
+- Overlay states should match the same world, reading as mission briefings rather than modal website messaging.
+
+## Implementation Scope
+- Primary changes should land in `styles.css`.
+- Small supporting text or class adjustments in `index.html` are acceptable if they improve theme coherence.
+- Gameplay logic and control behavior should remain untouched unless a style change requires tiny wiring support.
+
+## Risks And Mitigations
+- Risk: darker styling can reduce readability.
+  Mitigation: keep contrast high for labels, values, and button text.
+- Risk: strong theming can feel noisy on mobile.
+  Mitigation: simplify detail density on the dock while preserving the same palette and material language.
+- Risk: sidebar can still feel web-like if card rhythm remains too loose.
+  Mitigation: tighten spacing and treat sections as parts of one control stack.
+
+## Validation
+- The interface should read as a game screen at first glance, not as a landing page or dashboard.
+- The board remains the strongest focal point on both desktop and mobile.
+- Sidebar and dock controls feel consistent with the board theme and clearly interactive.

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
 
       <aside class="sidebar">
         <section class="card card--towers">
-          <h2>Towers</h2>
+          <h2>Loadout</h2>
           <p class="selection-summary selection-summary--desktop" data-selection-summary></p>
           <div class="tower-grid" id="tower-buttons">
             <button type="button" data-tower="attack" class="tower-choice">
@@ -149,7 +149,7 @@
         </section>
 
         <section class="card card--controls">
-          <h2>Controls</h2>
+          <h2>Command Keys</h2>
           <ul class="controls-list">
             <li>Move cursor: Arrow keys or WASD</li>
             <li>Select tower: 1 to 5 or click tower buttons</li>
@@ -161,7 +161,7 @@
         </section>
 
         <section class="card card--touch">
-          <h2>Touch Controls</h2>
+          <h2>Field Controls</h2>
           <div class="touch-grid">
             <button type="button" data-move="up">Up</button>
             <button type="button" data-action="build">Build</button>

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,33 @@
 :root {
-  color-scheme: light;
-  --bg: #ece7da;
-  --panel: #f8f5ec;
-  --ink: #1f2430;
-  --muted: #58606e;
-  --line: #b8ae99;
-  --accent: #355c3d;
-  --accent-strong: #253f2a;
-  --danger: #8a2d2d;
-  --road: #b38c5d;
-  --grass: #c9d6a2;
+  color-scheme: dark;
+  --bg: oklch(0.18 0.024 195);
+  --bg-deep: oklch(0.14 0.02 195);
+  --panel: oklch(0.24 0.03 78);
+  --panel-strong: oklch(0.29 0.038 78);
+  --panel-soft: oklch(0.27 0.026 92);
+  --panel-inset: oklch(0.2 0.022 84);
+  --line: oklch(0.49 0.05 75);
+  --line-soft: oklch(0.37 0.035 82);
+  --ink: oklch(0.92 0.02 92);
+  --ink-muted: oklch(0.76 0.02 88);
+  --accent: oklch(0.71 0.13 73);
+  --accent-strong: oklch(0.58 0.11 66);
+  --accent-soft: oklch(0.44 0.055 74);
+  --danger: oklch(0.62 0.16 28);
+  --success: oklch(0.7 0.11 145);
+  --shadow: 0 18px 40px rgba(5, 10, 10, 0.38);
+  --shadow-tight: 0 8px 18px rgba(5, 10, 10, 0.28);
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --title-font: "Trebuchet MS", "Arial Black", sans-serif;
+  --ui-font: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
 * {
@@ -18,56 +36,98 @@
 
 body {
   margin: 0;
-  background: var(--bg);
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(235, 168, 70, 0.12), transparent 30%),
+    radial-gradient(circle at 20% 20%, rgba(121, 149, 98, 0.16), transparent 28%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-deep) 100%);
   color: var(--ink);
-  font-family: Georgia, "Times New Roman", serif;
+  font-family: var(--ui-font);
 }
 
 button {
   font: inherit;
+  letter-spacing: 0.02em;
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease,
+    background 180ms ease,
+    color 120ms ease,
+    box-shadow 180ms ease;
+}
+
+button:hover:not(:disabled) {
+  border-color: var(--line);
+}
+
+button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 75%, white 25%);
+  outline-offset: 2px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .app-shell {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
-  gap: 16px;
-  padding: 16px;
-  max-width: 1280px;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  max-width: 1320px;
   margin: 0 auto;
 }
 
 .game-panel,
 .card {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  box-shadow: 0 2px 0 rgba(31, 36, 48, 0.08);
+  background:
+    linear-gradient(180deg, rgba(255, 245, 214, 0.06), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, var(--panel) 0%, var(--panel-inset) 100%);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
 }
 
 .game-panel {
-  padding: 16px;
+  position: relative;
+  padding: var(--space-4);
 }
 
 .hud {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 10px;
-  margin-bottom: 16px;
+  gap: 1px;
+  margin-bottom: var(--space-4);
+  padding: 1px;
+  border: 1px solid var(--line);
+  border-radius: calc(var(--radius-lg) - 4px);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.28), rgba(255, 214, 121, 0.06));
+  overflow: hidden;
 }
 
 .hud-block {
-  padding: 10px 12px;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.45);
+  padding: 11px 14px 12px;
+  background:
+    linear-gradient(180deg, rgba(255, 222, 154, 0.11), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, var(--panel-strong), var(--panel-inset));
+}
+
+.hud-block strong {
+  display: block;
+  margin-top: 4px;
+  font-family: var(--title-font);
+  font-size: 1.1rem;
+  letter-spacing: 0.05em;
+  color: var(--ink);
 }
 
 .hud-label {
   display: block;
-  font-size: 0.78rem;
-  color: var(--muted);
+  font-size: 0.7rem;
+  color: var(--ink-muted);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.16em;
 }
 
 .sr-only {
@@ -85,24 +145,46 @@ button {
 .board-frame {
   position: relative;
   border: 1px solid var(--line);
-  border-radius: 16px;
+  border-radius: 28px;
   overflow: hidden;
-  background: #d6dfb7;
+  background:
+    radial-gradient(circle at top, rgba(255, 192, 99, 0.12), transparent 22%),
+    linear-gradient(180deg, oklch(0.3 0.028 125), oklch(0.23 0.02 124));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 233, 176, 0.18),
+    inset 0 -20px 40px rgba(0, 0, 0, 0.18);
+}
+
+.board-frame::before {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 220, 156, 0.14);
+  pointer-events: none;
+  z-index: 1;
 }
 
 .board-pause-button {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 14px;
+  right: 14px;
   z-index: 3;
-  min-width: 110px;
+  min-width: 116px;
   padding: 10px 14px;
-  border-radius: 12px;
+  border-radius: 999px;
   border: 1px solid var(--line);
-  background: rgba(248, 245, 236, 0.94);
-  color: var(--ink);
-  box-shadow: 0 4px 12px rgba(31, 36, 48, 0.14);
+  background: linear-gradient(180deg, rgba(255, 215, 138, 0.94), rgba(168, 112, 44, 0.92));
+  color: oklch(0.2 0.02 70);
+  box-shadow: var(--shadow-tight);
   cursor: pointer;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.board-pause-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(5, 10, 10, 0.3);
 }
 
 #game-board {
@@ -116,10 +198,11 @@ button {
   inset: 0;
   display: grid;
   place-items: center;
-  background: rgba(31, 36, 48, 0.62);
-  color: white;
+  background: rgba(10, 15, 14, 0.68);
+  color: var(--ink);
   text-align: center;
-  padding: 24px;
+  padding: var(--space-5);
+  z-index: 2;
 }
 
 .overlay-message[hidden] {
@@ -131,7 +214,7 @@ button {
   display: flex;
   gap: 8px;
   transform: translate(-50%, -100%);
-  z-index: 2;
+  z-index: 4;
 }
 
 .tower-actions[hidden] {
@@ -139,49 +222,59 @@ button {
 }
 
 .tower-actions button {
-  width: 40px;
-  height: 40px;
-  border: 1px solid rgba(31, 36, 48, 0.2);
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(255, 220, 158, 0.24);
   border-radius: 999px;
-  background: rgba(248, 245, 236, 0.96);
+  background:
+    linear-gradient(180deg, rgba(255, 221, 154, 0.12), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, rgba(59, 49, 35, 0.98), rgba(32, 35, 27, 0.96));
   color: var(--ink);
-  box-shadow: 0 4px 12px rgba(31, 36, 48, 0.16);
+  box-shadow: var(--shadow-tight);
   cursor: pointer;
 }
 
 .tower-actions button:first-child {
-  color: var(--accent-strong);
+  color: var(--success);
 }
 
 .tower-actions button:last-child {
-  color: var(--danger);
+  color: color-mix(in srgb, var(--danger) 86%, white 14%);
 }
 
 .overlay-card {
-  width: min(100%, 420px);
-  padding: 24px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  background: rgba(20, 25, 34, 0.78);
+  width: min(100%, 460px);
+  padding: 28px;
+  border-radius: 26px;
+  border: 1px solid rgba(255, 216, 145, 0.28);
+  background:
+    linear-gradient(180deg, rgba(255, 220, 155, 0.16), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, rgba(47, 37, 24, 0.96), rgba(28, 31, 23, 0.94));
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.44);
 }
 
 .overlay-kicker {
-  margin: 0 0 8px;
-  font-size: 0.78rem;
-  letter-spacing: 0.12em;
+  margin: 0 0 10px;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.72);
+  color: color-mix(in srgb, var(--ink-muted) 78%, var(--accent) 22%);
 }
 
 .overlay-title {
   margin: 0 0 12px;
-  font-size: 2rem;
+  font-family: var(--title-font);
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  line-height: 0.95;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .overlay-body {
   margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.5;
+  color: var(--ink-muted);
+  font-size: 1rem;
+  line-height: 1.6;
 }
 
 .overlay-actions {
@@ -192,24 +285,26 @@ button {
 }
 
 .overlay-actions button {
-  min-width: 132px;
-  padding: 12px 16px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  background: #f4eee0;
+  min-width: 140px;
+  padding: 12px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 220, 158, 0.28);
+  background: linear-gradient(180deg, var(--panel-strong), var(--panel-inset));
   color: var(--ink);
   cursor: pointer;
+  text-transform: uppercase;
+  font-weight: 700;
 }
 
 .overlay-actions button:first-child {
-  background: var(--accent);
-  color: white;
-  border-color: var(--accent-strong);
+  background: linear-gradient(180deg, oklch(0.75 0.13 73), oklch(0.61 0.11 66));
+  color: oklch(0.2 0.02 70);
+  border-color: oklch(0.58 0.08 65);
 }
 
 .sidebar {
   display: grid;
-  gap: 16px;
+  gap: 12px;
   align-content: start;
 }
 
@@ -218,7 +313,7 @@ button {
 }
 
 .card {
-  padding: 16px;
+  padding: 14px;
 }
 
 .card h1,
@@ -228,13 +323,16 @@ button {
   margin-top: 0;
 }
 
-.card h1,
 .card h2 {
-  margin-bottom: 12px;
+  margin-bottom: 10px;
+  font-family: var(--title-font);
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .muted {
-  color: var(--muted);
+  color: var(--ink-muted);
   line-height: 1.45;
 }
 
@@ -257,18 +355,25 @@ button {
 .tower-choice,
 .touch-grid button {
   padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--line);
-  background: white;
+  border-radius: 16px;
+  border: 1px solid var(--line-soft);
+  background:
+    linear-gradient(180deg, rgba(255, 221, 154, 0.08), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, rgba(59, 49, 35, 0.95), rgba(32, 35, 27, 0.95));
   color: var(--ink);
   cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 231, 182, 0.09);
+}
+
+.tower-choice:hover:not(.is-selected) {
+  transform: translateY(-1px);
 }
 
 .tower-choice {
   display: grid;
   justify-items: center;
   gap: 8px;
-  min-height: 110px;
+  min-height: 118px;
   padding: 12px 10px;
   text-align: center;
 }
@@ -276,11 +381,14 @@ button {
 .tower-choice__icon {
   display: grid;
   place-items: center;
-  width: 58px;
-  height: 58px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.86);
-  border: 1px solid rgba(31, 36, 48, 0.08);
+  width: 60px;
+  height: 60px;
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at top, rgba(255, 214, 130, 0.2), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, rgba(27, 31, 26, 0.95), rgba(55, 45, 30, 0.95));
+  border: 1px solid rgba(255, 216, 145, 0.14);
+  box-shadow: inset 0 1px 0 rgba(255, 232, 186, 0.06);
 }
 
 .tower-choice__icon img {
@@ -290,56 +398,64 @@ button {
 }
 
 .tower-choice__meta {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
+  display: grid;
+  gap: 4px;
+  justify-items: center;
 }
 
 .tower-choice__key {
-  font-size: 0.72rem;
-  color: var(--muted);
+  font-size: 0.68rem;
+  color: var(--ink-muted);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
 }
 
 .tower-choice__name {
   line-height: 1.05;
+  font-weight: 700;
 }
 
 .tower-choice.is-selected,
-.touch-grid button:active {
-  background: var(--accent);
-  color: white;
-  border-color: var(--accent-strong);
+.touch-grid button:active,
+.dock-actions button:active,
+.dock-pad button:active {
+  background:
+    linear-gradient(180deg, rgba(255, 228, 166, 0.22), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, oklch(0.49 0.06 74), oklch(0.34 0.045 70));
+  border-color: var(--line);
+  color: oklch(0.97 0.01 95);
+  transform: translateY(1px);
 }
 
 .tower-choice.is-selected .tower-choice__icon {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.24);
+  background:
+    radial-gradient(circle at top, rgba(255, 234, 189, 0.26), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, rgba(83, 59, 29, 0.96), rgba(37, 31, 21, 0.96));
+  border-color: rgba(255, 230, 178, 0.3);
 }
 
 .tower-choice.is-selected .tower-choice__key {
-  color: rgba(255, 255, 255, 0.78);
+  color: rgba(255, 246, 225, 0.78);
 }
 
 .controls-list {
   margin: 0;
   padding-left: 18px;
-  line-height: 1.6;
+  color: var(--ink-muted);
+  line-height: 1.55;
 }
 
 .selection-summary {
   margin: 0 0 12px;
-  color: var(--muted);
-  min-height: 3.6em;
+  color: var(--ink-muted);
+  min-height: 3.8em;
+  line-height: 1.45;
 }
 
 .dock-label {
   margin: 0 0 8px;
   font-size: 0.76rem;
-  color: var(--muted);
+  color: var(--ink-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -367,9 +483,11 @@ button {
   display: grid;
   place-items: center;
   padding: 12px 14px;
-  border-radius: 12px;
-  border: 1px solid var(--line);
-  background: white;
+  border-radius: 14px;
+  border: 1px solid var(--line-soft);
+  background:
+    linear-gradient(180deg, rgba(255, 221, 154, 0.08), rgba(0, 0, 0, 0)),
+    linear-gradient(180deg, rgba(59, 49, 35, 0.95), rgba(32, 35, 27, 0.95));
   color: var(--ink);
   cursor: pointer;
   text-align: center;
@@ -419,13 +537,6 @@ button {
   stroke-width: 2.25;
 }
 
-.dock-actions button:active,
-.dock-pad button:active {
-  background: var(--accent);
-  color: white;
-  border-color: var(--accent-strong);
-}
-
 @media (max-width: 1024px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -442,28 +553,23 @@ button {
     padding-bottom: 230px;
   }
 
-  .hud {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    align-items: stretch;
-  }
-
   .game-panel {
     padding: 10px;
   }
 
   .hud {
-    gap: 6px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1px;
     margin-bottom: 10px;
   }
 
   .hud-block {
     padding: 8px 10px;
-    border-radius: 10px;
   }
 
   .hud-label {
-    font-size: 0.68rem;
-    letter-spacing: 0.06em;
+    font-size: 0.64rem;
+    letter-spacing: 0.1em;
   }
 
   .hud-block strong {
@@ -473,6 +579,11 @@ button {
 
   .board-frame {
     border-radius: 18px;
+  }
+
+  .board-frame::before {
+    inset: 8px;
+    border-radius: 12px;
   }
 
   .board-pause-button {
@@ -519,10 +630,12 @@ button {
     bottom: 10px;
     z-index: 8;
     padding: 14px;
-    border-radius: 20px;
+    border-radius: 24px;
     border: 1px solid var(--line);
-    background: rgba(248, 245, 236, 0.97);
-    box-shadow: 0 10px 28px rgba(31, 36, 48, 0.18);
+    background:
+      linear-gradient(180deg, rgba(255, 214, 138, 0.14), rgba(0, 0, 0, 0)),
+      linear-gradient(180deg, rgba(49, 41, 29, 0.96), rgba(22, 24, 20, 0.96));
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.42);
     backdrop-filter: blur(8px);
   }
 
@@ -549,10 +662,6 @@ button {
   .tower-choice__icon img {
     width: 34px;
     height: 34px;
-  }
-
-  .tower-choice__meta {
-    gap: 4px;
   }
 
   .tower-choice__name {

--- a/styles.css
+++ b/styles.css
@@ -79,7 +79,6 @@ button:disabled {
   margin: 0 auto;
 }
 
-.game-panel,
 .card {
   background:
     linear-gradient(180deg, rgba(255, 245, 214, 0.06), rgba(0, 0, 0, 0)),
@@ -92,6 +91,10 @@ button:disabled {
 .game-panel {
   position: relative;
   padding: var(--space-4);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .hud {
@@ -108,9 +111,11 @@ button:disabled {
 
 .hud-block {
   padding: 11px 14px 12px;
-  background:
-    linear-gradient(180deg, rgba(255, 222, 154, 0.11), rgba(0, 0, 0, 0)),
-    linear-gradient(180deg, var(--panel-strong), var(--panel-inset));
+  background: color-mix(in srgb, var(--panel-strong) 82%, black 18%);
+}
+
+.hud-block:nth-child(2n) {
+  background: color-mix(in srgb, var(--panel) 76%, black 24%);
 }
 
 .hud-block strong {
@@ -144,6 +149,7 @@ button:disabled {
 
 .board-frame {
   position: relative;
+  min-height: 380px;
   border: 1px solid var(--line);
   border-radius: 28px;
   overflow: hidden;
@@ -244,6 +250,7 @@ button:disabled {
 
 .overlay-card {
   width: min(100%, 460px);
+  min-height: 320px;
   padding: 28px;
   border-radius: 26px;
   border: 1px solid rgba(255, 216, 145, 0.28);
@@ -251,6 +258,8 @@ button:disabled {
     linear-gradient(180deg, rgba(255, 220, 155, 0.16), rgba(0, 0, 0, 0)),
     linear-gradient(180deg, rgba(47, 37, 24, 0.96), rgba(28, 31, 23, 0.94));
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.44);
+  display: grid;
+  align-content: center;
 }
 
 .overlay-kicker {
@@ -578,6 +587,7 @@ button:disabled {
   }
 
   .board-frame {
+    min-height: 400px;
     border-radius: 18px;
   }
 
@@ -599,6 +609,7 @@ button:disabled {
 
   .overlay-card {
     width: min(100%, 360px);
+    min-height: 340px;
     padding: 18px;
   }
 
@@ -673,6 +684,10 @@ button:disabled {
   .dock-actions button {
     min-height: 46px;
     font-weight: 700;
+  }
+
+  .dock-selection-summary {
+    margin-bottom: 8px;
   }
 
   .dock-pad button {


### PR DESCRIPTION
## Summary
- retheme the tower defense UI to feel more game-native and tighten the mobile presentation
- address browser review feedback around nested panels, HUD styling, and overlay sizing
- add CI and GitHub Pages workflows so successful main CI runs build and deploy the site

## Test Plan
- [x] npm test
- [x] npm run build
- [x] npm run build -- --base='/tower-defense/'