### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,21 +31,21 @@ jobs:
 
     steps:
       - name: Checkout workflow dispatch ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: github.event_name == 'workflow_dispatch'
         with:
           ref: ${{ github.ref }}
 
       - name: Checkout successful CI commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: github.event_name == 'workflow_run'
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v5
- upgrade actions/setup-node from v4 to v5
- run CI workflows on Node.js 24 instead of Node.js 20

## Test Plan
- npm test
- npm run build